### PR TITLE
Add LSST SQuaRE team

### DIFF
--- a/deployments/astro.pangeo.io/config/auth.yaml
+++ b/deployments/astro.pangeo.io/config/auth.yaml
@@ -2,6 +2,7 @@ jupyterhub:
   auth:
     github:
       org_whitelist:
+        -  lsst-sqre
         -  pangeo-data
         -  dask
         -  xarray-dev


### PR DESCRIPTION
The SQuaRE team in the LSST project are looking at similar technologies and would benefit from seeing this deployment.